### PR TITLE
Add objc flag to LinkWith

### DIFF
--- a/FSCalendar/LinkWith.cs
+++ b/FSCalendar/LinkWith.cs
@@ -1,3 +1,3 @@
 ﻿using ObjCRuntime;
 
-[assembly: LinkWith("libFSCalendar.a", LinkTarget.i386 | LinkTarget.x86_64 | LinkTarget.Arm64 | LinkTarget.ArmV7  | LinkTarget.Simulator, SmartLink = true, ForceLoad = true, Frameworks = "NotificationCenter UIKit Foundation CoreGraphics")] 
+[assembly: LinkWith("libFSCalendar.a", LinkTarget.i386 | LinkTarget.x86_64 | LinkTarget.Arm64 | LinkTarget.ArmV7 | LinkTarget.Simulator, SmartLink = true, ForceLoad = true, Frameworks = "NotificationCenter UIKit Foundation CoreGraphics", LinkerFlags = "-ObjC")]


### PR DESCRIPTION
If the ObjC flag is not present in LinkWith, users are obligated to implement that flag by theirselves (or the library might crash in runtime).

Reference from [Xamarin Forums](https://forums.xamarin.com/discussion/44514/ios-binding-works-fine-in-simulator-but-throws-exception-on-device)

Solves #7 